### PR TITLE
過去の記録ページの実装

### DIFF
--- a/app/Livewire/Meal/GetMealRecordsPage.php
+++ b/app/Livewire/Meal/GetMealRecordsPage.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Livewire\Meal;
+
+use App\Models\Meal;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class GetMealRecordsPage extends Component
+{
+    use WithPagination;
+
+    public Collection $mealRecords;
+    public Carbon $today;
+    public Carbon $startOfWeek;
+    public Carbon $endOfWeek;
+    public array $week = [];
+    public ?string $selectedDate= null;
+
+    public function mount()
+    {
+        $this->today = Carbon::now();
+        $this->selectedDate = $this->today->toDateString();
+        $this->initializeDates($this->today);
+        $this->fetchMealRecords($this->startOfWeek, $this->endOfWeek);
+    }
+
+    /**
+     * 該当の日付の週を初期化するメソッド
+     */
+    private function initializeDates($date)
+    {
+        $this->startOfWeek = $date->copy()->startOfWeek();
+        $this->endOfWeek = $date->copy()->endOfWeek();
+        $this->week = [];
+        // 今週の日付を配列で取得
+        for ($i = 0; $i < 7; $i++) {
+            $this->week[] = $this->startOfWeek->copy()->addDays($i);
+        }
+    }
+
+    /**
+     * 食事記録を取得するメソッド
+     */
+    private function fetchMealRecords($startOfWeek, $endOfWeek)
+    {
+        $this->mealRecords = Meal::query()
+            ->where('user_id', auth()->id())
+            ->whereBetween('date', [$startOfWeek, $endOfWeek])
+            ->orderBy('date', 'asc')
+            ->orderBy('meal_type', 'asc')
+            ->with('foods') // リレーションをロード
+            ->get()
+            ->map(function ($meal) {
+                $meal->total_calories = $meal->foods->sum(function ($food) {
+                    return $food->calorie * ($food->pivot->quantity / 100);
+                });
+                return $meal;
+            });
+    }
+
+    /**
+     * 選択した日付の食事記録を取得するメソッド
+     */
+    #[On('getMealRecordsByDate')]
+    public function getMealRecordsByDate()
+    {
+        if (!$this->selectedDate) {
+            return;
+        }
+        $selectedDate = Carbon::parse($this->selectedDate);
+        $this->initializeDates($selectedDate);
+        $this->fetchMealRecords($this->startOfWeek, $this->endOfWeek);
+
+    }
+
+    /**
+     * selectedDateの日付を一週間分遡るメソッド
+     */
+    public function showPreviousWeek()
+    {
+        $this->selectedDate = Carbon::parse($this->selectedDate)->subWeek()->toDateString();
+        $this->getMealRecordsByDate();
+    }
+
+    /**
+     * selectedDateの日付を一週間分進めるメソッド
+     */
+    public function showNextWeek()
+    {
+        $this->selectedDate = Carbon::parse($this->selectedDate)->addWeek()->toDateString();
+        $this->getMealRecordsByDate();
+    }
+
+    public function render()
+    {
+        return view('livewire.meal.get-meal-records-page')->layout('layouts.app');
+    }
+}

--- a/app/Models/Food.php
+++ b/app/Models/Food.php
@@ -45,7 +45,7 @@ class Food extends Model
      */
     public function meals() : BelongsToMany
     {
-        return $this->belongsToMany(Meal::class)->using(MealFood::class);
+        return $this->belongsToMany(Meal::class,'meal_food')->withPivot('quantity')->withTimestamps();
     }
 
     /**
@@ -55,5 +55,13 @@ class Food extends Model
     public function categories() : BelongsToMany
     {
         return $this->belongsToMany(Category::class);
+    }
+
+    public function getShortNameAttribute()
+    {
+        // 正規表現を使用して<>や()、[]に囲まれた文字列を除外
+        $cleanName = preg_replace('/[<\(\[\（\【\《\＜\［].*?[>\)\]\）\】\》\＞\］]/u', '', $this->name);
+
+        return preg_replace('/\s/u', '', $cleanName);
     }
 }

--- a/app/Models/Meal.php
+++ b/app/Models/Meal.php
@@ -46,6 +46,21 @@ class Meal extends Model
      */
     public function foods()
     {
-        return $this->belongsToMany(Food::class)->using(MealFood::class);
+        return $this->belongsToMany(Food::class,'meal_food')->withPivot('quantity')->withTimestamps();
+    }
+
+    /**
+     * 食事タイプの表示
+     * @return string
+     */
+    public function getMealTypeAttribute(): string
+    {
+        $mealTypes = [
+            0 => '朝食',
+            1 => '昼食',
+            2 => '夕食',
+            3 => '間食',
+        ];
+        return $mealTypes[$this->attributes['meal_type']];
     }
 }

--- a/app/Services/Meal/InsertMealService.php
+++ b/app/Services/Meal/InsertMealService.php
@@ -23,14 +23,14 @@ class InsertMealService
         try {
             $this->validateMealRequest($request);
             DB::beginTransaction();
-            $meal = Meal::query()->create([
+            $meal = Meal::query()->updateOrCreate([
                 'user_id' => Auth::id(),
                 'date' => $request['date'],
                 'meal_type' => $request['meal_type'],
             ]);
-
+            $meal->foods()->detach();
             foreach ($request['foods'] as $food) {
-                MealFood::query()->create([
+                MealFood::query()->updateOrCreate([
                     'meal_id' => $meal->id,
                     'food_id' => $food['id'],
                     'quantity' => $food['quantity'],

--- a/database/factories/MealFactory.php
+++ b/database/factories/MealFactory.php
@@ -17,9 +17,9 @@ class MealFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => 1,
-            'date' => now(),
-            'meal_type' => 0,
+            'user_id' => \App\Models\User::factory(), // 動的にユーザーを生成
+            'date' => $this->faker->dateTimeThisYear(), // fakerを使用してランダムな日付を生成
+            'meal_type' => $this->faker->numberBetween(0, 2), // 0から2の範囲でランダムな値を生成
         ];
     }
 }

--- a/database/factories/MealFactory.php
+++ b/database/factories/MealFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Meal>
+ */
+class MealFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => 1,
+            'date' => now(),
+            'meal_type' => 0,
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,5 +21,6 @@ class DatabaseSeeder extends Seeder
         ]);
         $this->call(CategorySeeder::class);
         $this->call(FoodSeeder::class);
+        $this->call(MealSeeder::class);
     }
 }

--- a/database/seeders/MealSeeder.php
+++ b/database/seeders/MealSeeder.php
@@ -21,21 +21,25 @@ class MealSeeder extends Seeder
         $foods = Food::inRandomOrder()->limit(30)->get();
 
         foreach (range(0, 20) as $i) {
-            foreach ($mealTypes as $mealType) {
-                $meal = [
-                    'user_id' => 1,
-                    'date' => $startOfDate->copy()->addDays($i),
-                    'meal_type' => $mealType,
-                ];
-                $mealFood = $foods->random(3)->mapWithKeys(function ($food) {
-                    return [
-                        $food->id => ['quantity' => rand(100, 300),]
+            $date = $startOfDate->copy()->addDays($i);
+            $this->createMealsForDate($date, $foods, $mealTypes);
+        }
+    }
 
-                    ];
-                })->toArray();
-                $mealId = Meal::factory()->create($meal)->id;
-                Meal::find($mealId)->foods()->attach($mealFood);
-            }
+    private function createMealsForDate($date, $foods, $mealTypes) {
+        foreach ($mealTypes as $mealType) {
+            $meal = [
+                'user_id' => 1,
+                'date' => $date,
+                'meal_type' => $mealType,
+            ];
+            $mealFood = $foods->random(3)->mapWithKeys(function ($food) {
+                return [
+                    $food->id => ['quantity' => rand(100, 300)],
+                ];
+            })->toArray();
+            $mealId = Meal::factory()->create($meal)->id;
+            Meal::find($mealId)->foods()->attach($mealFood);
         }
     }
 }

--- a/database/seeders/MealSeeder.php
+++ b/database/seeders/MealSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Food;
+use App\Models\Meal;
+use Illuminate\Database\Seeder;
+
+class MealSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $date = now();
+        $startOfDate = $date->startOfWeek()->subWeek();
+        $mealTypes = [0, 1, 2, 3];
+
+        // ランダムなFoodレコード20件を取得
+        $foods = Food::inRandomOrder()->limit(30)->get();
+
+        foreach (range(0, 20) as $i) {
+            foreach ($mealTypes as $mealType) {
+                $meal = [
+                    'user_id' => 1,
+                    'date' => $startOfDate->copy()->addDays($i),
+                    'meal_type' => $mealType,
+                ];
+                $mealFood = $foods->random(3)->mapWithKeys(function ($food) {
+                    return [
+                        $food->id => ['quantity' => rand(100, 300),]
+
+                    ];
+                })->toArray();
+                $mealId = Meal::factory()->create($meal)->id;
+                Meal::find($mealId)->foods()->attach($mealFood);
+            }
+        }
+    }
+}

--- a/database/seeders/MealSeeder.php
+++ b/database/seeders/MealSeeder.php
@@ -28,7 +28,7 @@ class MealSeeder extends Seeder
 
     private function createMealsForDate($date, $foods, $mealTypes) {
         foreach ($mealTypes as $mealType) {
-            $meal = [
+            $mealParam = [
                 'user_id' => 1,
                 'date' => $date,
                 'meal_type' => $mealType,
@@ -38,8 +38,8 @@ class MealSeeder extends Seeder
                     $food->id => ['quantity' => rand(100, 300)],
                 ];
             })->toArray();
-            $mealId = Meal::factory()->create($meal)->id;
-            Meal::find($mealId)->foods()->attach($mealFood);
+            $meal = Meal::factory()->create($mealParam);
+            $meal->foods()->attach($mealFood);
         }
     }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,6 +10,7 @@
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/resources/views/livewire/meal/get-meal-records-page.blade.php
+++ b/resources/views/livewire/meal/get-meal-records-page.blade.php
@@ -4,23 +4,24 @@
             <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
                 {{ __('これまでの食事記録') }}
             </h2>
-            <form wire:submit.prevent="getMealRecordsByDate" class="w-1/3 rounded-lg flex justify-center items-center">
-                <div class="flex-1">
-                    <div class="flex justify-center">
-                        <input type="date" id="date" wire:model="selectedDate"
-                            class="w-3/4 border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
-                        <button type="submit"
-                            class="bg-slate-400 hover:bg-slate-500 text-sm text-white font-bold ml-2 p-2 rounded focus:outline-none focus:shadow-outline">
-                            <span class="material-symbols-outlined align-middle">
-                                search
-                            </span>
-                        </button>
-                    </div>
-                </div>
-            </form>
         </div>
     </x-slot>
-
+    <div class="flex justify-center mb-6">
+        <form wire:submit.prevent="getMealRecordsByDate" class="w-1/3 rounded-lg flex justify-center items-center">
+            <div class="flex-1">
+                <div class="flex justify-center">
+                    <input type="date" id="date" wire:model="selectedDate"
+                        class="w-3/4 border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                    <button type="submit"
+                        class="bg-slate-400 hover:bg-slate-500 text-sm text-white font-bold ml-2 p-2 rounded focus:outline-none focus:shadow-outline">
+                        <span class="material-symbols-outlined align-middle">
+                            search
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
     <div class="overflow-x-auto">
         <div class="min-w-max">
             <div class="grid grid-cols-8 gap-0 border border-gray-600">

--- a/resources/views/livewire/meal/get-meal-records-page.blade.php
+++ b/resources/views/livewire/meal/get-meal-records-page.blade.php
@@ -1,0 +1,91 @@
+<div class="container mx-auto px-4 py-6">
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                {{ __('これまでの食事記録') }}
+            </h2>
+            <form wire:submit.prevent="getMealRecordsByDate" class="w-1/3 rounded-lg flex justify-center items-center">
+                <div class="flex-1">
+                    <div class="flex justify-center">
+                        <input type="date" id="date" wire:model="selectedDate"
+                            class="w-3/4 border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                        <button type="submit"
+                            class="bg-slate-400 hover:bg-slate-500 text-sm text-white font-bold ml-2 p-2 rounded focus:outline-none focus:shadow-outline">
+                            <span class="material-symbols-outlined align-middle">
+                                search
+                            </span>
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </x-slot>
+
+    <div class="overflow-x-auto">
+        <div class="min-w-max">
+            <div class="grid grid-cols-8 gap-0 border border-gray-600">
+                <!-- Header Row -->
+                <div
+                    class="sticky left-0 col-span-1 font-bold border border-gray-600 px-2 py-2 text-center bg-orange-200 ">
+                    種類</div>
+                @foreach ($week as $date)
+                    <div class="col-span-1 font-bold border border-gray-600 px-4 py-2 text-center bg-orange-200 ">
+                        {{ $date->format('m/d(D)') }}</div>
+                @endforeach
+                <!-- Data Rows -->
+                @foreach (['朝食', '昼食', '夕食', '間食'] as $mealType)
+                    <div
+                        class="sticky left-0 col-span-1 font-bold border border-gray-600 px-2 py-2 bg-orange-200 text-center place-content-center h-40 overflow-auto">
+                        {{ $mealType }}
+                    </div>
+                    @foreach ($week as $date)
+                        <div
+                            class="col-span-1 border border-gray-600 px-4 py-2 {{ $today->format('Y-m-d') === $date->format('Y-m-d') ? 'bg-yellow-100' : 'bg-white' }} h-40 overflow-auto">
+                            @php
+                                $meal = $mealRecords
+                                    ->where('date', $date->format('Y-m-d'))
+                                    ->firstWhere('meal_type', $mealType);
+                            @endphp
+                            @if ($meal)
+                                <ul>
+                                    <li>総摂取カロリー: {{ round($meal->total_calories) }} kcal</li>
+                                    <li>
+                                        <ul>
+                                            @foreach ($meal->foods as $food)
+                                                <li class="text-sm py-2">{{ $food->short_name }}</li>
+                                            @endforeach
+                                        </ul>
+                                    </li>
+                                </ul>
+                            @else
+                                <p>登録なし</p>
+                            @endif
+                        </div>
+                    @endforeach
+                @endforeach
+            </div>
+        </div>
+    </div>
+    <div class="flex justify-center items-center">
+        <form wire:submit.prevent="showPreviousWeek">
+            <input type="hidden" wire:model="selectedDate">
+            <button type="submit" class="m-2 font-bold text-slate-500 rounded hover:text-slate-700">
+                <span class="material-symbols-outlined align-middle">
+                    chevron_left
+                </span>
+            </button>
+        </form>
+        <div class="m-2 font-bold text-slate-500">
+            {{ $startOfWeek->format('Y年m月') }}
+            第{{ ceil((date('d', strtotime($startOfWeek)) - date('w', strtotime($startOfWeek)) - 1) / 7) + 1 }}週目
+        </div>
+        <form wire:submit.prevent="showNextWeek">
+            <input type="hidden" wire:model="selectedDate">
+            <button type="submit" class="m-2 font-bold text-slate-500 rounded hover:text-slate-700">
+                <span class="material-symbols-outlined align-middle">
+                    chevron_right
+                </span>
+            </button>
+        </form>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Livewire\Home\HomeComponent;
 use App\Livewire\Meal\InsertMealComponent;
 use App\Livewire\Meal\InsertMealPage;
 use App\Livewire\Goal\SetGoalModal;
+use App\Livewire\Meal\GetMealRecordsPage;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -19,4 +20,5 @@ Route::middleware([
     Route::get('meal/create', InsertMealPage::class)->name('meal.create');
     Route::post('meal/store', [InsertMealComponent::class, 'insertMeal'])->name('meal.store');
     Route::put('goal/update', [SetGoalModal::class, 'upsert'])->name('goal.update');
+    Route::get('meal/records', GetMealRecordsPage::class)->name('meal.records');
 });


### PR DESCRIPTION
# issue
#7

#

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - ユーザーが週ごとの食事記録を管理・表示できる新しいコンポーネント「GetMealRecordsPage」を追加。
  - 食事の登録、取得、週の移動機能を実装。
  - 食品モデルにおいて、食品名の簡略表示機能を追加。
  - 食事モデルにおいて、食事タイプのローカライズ表示機能を追加。

- **バグ修正**
  - 重複食事エントリーを避けるため、食事の作成・更新ロジックを改善。

- **ドキュメント**
  - データベースシーダーに食事データのシーディングを追加。

- **スタイル**
  - 新しいフォントスタイルを適用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->